### PR TITLE
maps instead of slices

### DIFF
--- a/convertfunctions.go
+++ b/convertfunctions.go
@@ -16,7 +16,7 @@ import (
 // 4. build CANFrame
 // 5. returning the CANFrame
 func convert2CAN(topic, payload string) can.Frame {
-	convertMethod := getConvTopic(topic)
+	convertMethod := getConvModeFromTopic(topic)
 	var Id = uint32(getId(topic))
 	var data [8]byte
 	var length uint8
@@ -179,7 +179,7 @@ func convert2CAN(topic, payload string) can.Frame {
 // 4. building a string
 // 5. return
 func convert2MQTT(id int, length int, payload [8]byte) string {
-	convertMethod := getConvId(id)
+	convertMethod := getConvModeFromId(id)
 	if convertMethod == "none" {
 		if dbg {
 			fmt.Printf("convertfunctions: using convertmode none\n")

--- a/convertfunctions.go
+++ b/convertfunctions.go
@@ -17,7 +17,7 @@ import (
 // 5. returning the CANFrame
 func convert2CAN(topic, payload string) can.Frame {
 	convertMethod := getConvModeFromTopic(topic)
-	var Id = uint32(getId(topic))
+	var Id = uint32(getIdFromTopic(topic))
 	var data [8]byte
 	var length uint8
 	if convertMethod == "none" {

--- a/main.go
+++ b/main.go
@@ -118,13 +118,15 @@ func readC2MPFromFile(filename string) {
 		if err == io.EOF {
 			break
 		}
-		i, err := strconv.Atoi(record[0])
-		if isInSlice(i, record[2]) {
+		canID, err := strconv.Atoi(record[0])
+		convMode := record[1]
+		topic := record[2]
+		if isInSlice(canID, topic) {
 			panic("main: each ID and each topic is only allowed once!")
 		}
-		can2mqttPairs = append(can2mqttPairs, can2mqtt{i, record[1], record[2]})
-		mqttSubscribe(record[2])
-		canSubscribe(uint32(i))
+		can2mqttPairs = append(can2mqttPairs, can2mqtt{canID, convMode, topic})
+		mqttSubscribe(topic)        // TODO move to append function
+		canSubscribe(uint32(canID)) // TODO move to append function
 	}
 	if dbg {
 		fmt.Printf("main: the following CAN-MQTT pairs have been extracted:\n")
@@ -160,7 +162,7 @@ func getTopic(canId int) string {
 }
 
 // get the conversion mode for a given topic
-func getConvTopic(topic string) string {
+func getConvModeFromTopic(topic string) string {
 	for _, c2mp := range can2mqttPairs {
 		if c2mp.mqttTopic == topic {
 			return c2mp.convMethod
@@ -182,7 +184,7 @@ func getId(mqttTopic string) int {
 }
 
 // get the convertMode for a given ID
-func getConvId(canId int) string {
+func getConvModeFromId(canId int) string {
 	for _, c2mp := range can2mqttPairs {
 		if c2mp.canId == canId {
 			return c2mp.convMethod

--- a/main.go
+++ b/main.go
@@ -21,12 +21,13 @@ type can2mqtt struct {
 	mqttTopic  string
 }
 
-var can2mqttPairs []can2mqtt    // representation of can2mqtt.csv
-var dbg = false                 // verbose on off [-v]
-var ci = "can0"                 // the CAN-Interface [-c]
-var cs = "tcp://localhost:1883" // mqtt-connect-string [-m]
-var c2mf = "can2mqtt.csv"       // path to the can2mqtt.csv [-f]
-var dirMode = 0                 // directional modes: 0=bidirectional 1=can2mqtt only 2=mqtt2can only [-d]
+var pairFromID map[int]*can2mqtt       // c2m pair (lookup from ID)
+var pairFromTopic map[string]*can2mqtt // c2m pair (lookup from Topic)
+var dbg = false                        // verbose on off [-v]
+var ci = "can0"                        // the CAN-Interface [-c]
+var cs = "tcp://localhost:1883"        // mqtt-connect-string [-m]
+var c2mf = "can2mqtt.csv"              // path to the can2mqtt.csv [-f]
+var dirMode = 0                        // directional modes: 0=bidirectional 1=can2mqtt only 2=mqtt2can only [-d]
 var wg sync.WaitGroup
 
 // SetDbg decides whether there is really verbose output or
@@ -112,6 +113,8 @@ func readC2MPFromFile(filename string) {
 	}
 
 	r := csv.NewReader(bufio.NewReader(file))
+	pairFromID = make(map[int]*can2mqtt)
+	pairFromTopic = make(map[string]*can2mqtt)
 	for {
 		record, err := r.Read()
 		// Stop at EOF.
@@ -124,14 +127,19 @@ func readC2MPFromFile(filename string) {
 		if isInSlice(canID, topic) {
 			panic("main: each ID and each topic is only allowed once!")
 		}
-		can2mqttPairs = append(can2mqttPairs, can2mqtt{canID, convMode, topic})
+		pairFromID[canID] = &can2mqtt{
+			canId:      canID,
+			convMethod: convMode,
+			mqttTopic:  topic,
+		}
+		pairFromTopic[topic] = pairFromID[canID]
 		mqttSubscribe(topic)        // TODO move to append function
 		canSubscribe(uint32(canID)) // TODO move to append function
 	}
 	if dbg {
 		fmt.Printf("main: the following CAN-MQTT pairs have been extracted:\n")
 		fmt.Printf("main: CAN-ID\t\t conversion mode\t\tMQTT-topic\n")
-		for _, c2mp := range can2mqttPairs {
+		for _, c2mp := range pairFromID {
 			fmt.Printf("main: %d\t\t%s\t\t%s\n", c2mp.canId, c2mp.convMethod, c2mp.mqttTopic)
 		}
 	}
@@ -139,57 +147,37 @@ func readC2MPFromFile(filename string) {
 
 // check function to check if a topic or an ID is in the slice
 func isInSlice(canId int, mqttTopic string) bool {
-	for _, c2mp := range can2mqttPairs {
-		if c2mp.canId == canId || c2mp.mqttTopic == mqttTopic {
-			if dbg {
-				fmt.Printf("main: The ID %d or the Topic %s is already in the list!\n", canId, mqttTopic)
-			}
-			return true
+	if pairFromID[canId] != nil {
+		if dbg {
+			fmt.Printf("main: The ID %d or the Topic %s is already in the list!\n", canId, mqttTopic)
 		}
+		return true
+	}
+	if pairFromTopic[mqttTopic] != nil {
+		if dbg {
+			fmt.Printf("main: The ID %d or the Topic %s is already in the list!\n", canId, mqttTopic)
+		}
+		return true
 	}
 	return false
 }
 
-// get the corresponding topic for an ID
-func getTopic(canId int) string {
-	for _, c2mp := range can2mqttPairs {
-		if c2mp.canId == canId {
-			return c2mp.mqttTopic
-		}
-	}
-	// err
-	return "-1"
+// get the corresponding ID for a given topic
+func getIdFromTopic(topic string) int {
+	return pairFromTopic[topic].canId
 }
 
 // get the conversion mode for a given topic
 func getConvModeFromTopic(topic string) string {
-	for _, c2mp := range can2mqttPairs {
-		if c2mp.mqttTopic == topic {
-			return c2mp.convMethod
-		}
-	}
-	// err
-	return "-1"
-}
-
-// get the corresponding ID for a given topic
-func getId(mqttTopic string) int {
-	for _, c2mp := range can2mqttPairs {
-		if c2mp.mqttTopic == mqttTopic {
-			return c2mp.canId
-		}
-	}
-	// err
-	return -1
+	return pairFromTopic[topic].convMethod
 }
 
 // get the convertMode for a given ID
 func getConvModeFromId(canId int) string {
-	for _, c2mp := range can2mqttPairs {
-		if c2mp.canId == canId {
-			return c2mp.convMethod
-		}
-	}
-	// err
-	return "-1"
+	return pairFromID[canId].convMethod
+}
+
+// get the corresponding topic for an ID
+func getTopicFromId(canId int) string {
+	return pairFromID[canId].mqttTopic
 }

--- a/receivehandling.go
+++ b/receivehandling.go
@@ -18,7 +18,7 @@ func handleCAN(cf can.Frame) {
 	if dbg {
 		fmt.Printf("receivehandler: converted String: %s\n", mqttPayload)
 	}
-	topic := getTopic(int(cf.ID))
+	topic := getTopicFromId(int(cf.ID))
 	if dirMode != 2 {
 		mqttPublish(topic, mqttPayload)
 		fmt.Printf("ID: %d len: %d data: %X -> topic: \"%s\" message: \"%s\"\n", cf.ID, cf.Length, cf.Data, topic, mqttPayload)


### PR DESCRIPTION
- Renames variables and introduces some to increase code readability
- Use maps as internal representation of can2mqtt.csv
